### PR TITLE
refactor: remove PvP Club-specific code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,19 +18,10 @@ java {
 
 repositories {
     maven { url = uri("https://repo.codemc.io/repository/maven-releases/") }
-    maven {
-        url = uri(findProperty("repsyUrl")!!)
-        credentials {
-            username = findProperty("repsyUsername").toString()
-            password = findProperty("repsyPassword").toString()
-        }
-    }
 }
 
 dependencies {
     paperweight.paperDevBundle("1.20.1-R0.1-SNAPSHOT")
-
-    compileOnly("xyz.reknown.duelsplugin:DuelsPluginAPI:1.0.5")
 
     // Shadow will include the runtimeClasspath by default, which implementation adds to.
     // Dependencies you don't want to include go in the compileOnly configuration.

--- a/src/main/java/xyz/reknown/fastercrystals/FasterCrystals.java
+++ b/src/main/java/xyz/reknown/fastercrystals/FasterCrystals.java
@@ -13,7 +13,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
-import xyz.reknown.duelsplugin.api.CrystalAPI;
 import xyz.reknown.fastercrystals.commands.impl.FastcrystalsCommand;
 import xyz.reknown.fastercrystals.listeners.bukkit.EntityRemoveFromWorldListener;
 import xyz.reknown.fastercrystals.listeners.bukkit.EntitySpawnListener;
@@ -30,7 +29,6 @@ import java.util.Map;
 public class FasterCrystals extends JavaPlugin {
     @Getter private Users users;
     private Map<Integer, EnderCrystal> crystalIds;
-    private CrystalAPI crystalApi;
 
     @Override
     public void onLoad() {
@@ -43,10 +41,6 @@ public class FasterCrystals extends JavaPlugin {
     @Override
     public void onEnable() {
         this.crystalIds = new HashMap<>();
-
-        if (getServer().getPluginManager().getPlugin("DuelsPlugin") != null) {
-            this.crystalApi = getServer().getServicesManager().load(CrystalAPI.class);
-        }
 
         this.users = new Users();
 
@@ -87,10 +81,7 @@ public class FasterCrystals extends JavaPlugin {
         clonedLoc.add(0.5, 1.0, 0.5);
         List<Entity> nearbyEntities = new ArrayList<>(clonedLoc.getWorld().getNearbyEntities(clonedLoc, 0.5, 1, 0.5));
 
-        boolean shouldPlaceCrystal;
-        if (this.crystalApi == null) shouldPlaceCrystal = nearbyEntities.isEmpty();
-        else shouldPlaceCrystal = this.crystalApi.canPlaceCrystal(nearbyEntities, true);
-        if (shouldPlaceCrystal) {
+        if (nearbyEntities.isEmpty()) {
             loc.getWorld().spawn(clonedLoc.subtract(0.0, 1.0, 0.0), EnderCrystal.class, entity -> entity.setShowingBottom(false));
 
             if (player.getGameMode() != GameMode.CREATIVE && player.getGameMode() != GameMode.SPECTATOR) {


### PR DESCRIPTION
Currently users who do not have proper authorization cannot build the project due to the DuelsPluginAPI being private.

For public use, this PR removes code specific to PvP Club so that it can be used standalone on any server.