### PR TITLE
refactor!: unshade packetevents and CommandAPI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,17 +43,18 @@ dependencies {
     paperweight.paperDevBundle("1.20.6-R0.1-SNAPSHOT")
 
     compileOnly("me.clip:placeholderapi:2.11.6")
-
-    implementation("com.github.retrooper:packetevents-spigot:2.8.0-SNAPSHOT")
-    implementation("dev.jorel:commandapi-bukkit-shade-mojang-mapped:10.0.0")
+    compileOnly("com.github.retrooper:packetevents-spigot:2.8.0-SNAPSHOT")
+    compileOnly("dev.jorel:commandapi-bukkit-core:10.0.0")
 
     compileOnly("org.projectlombok:lombok:1.18.38")
     annotationProcessor("org.projectlombok:lombok:1.18.38")
 }
 
 tasks {
-    build {
-        dependsOn("shadowJar")
+    jar {
+        from(rootDir) {
+            include("LICENSE")
+        }
     }
     compileJava {
         // Set the release flag. This configures what version bytecode the compiler will emit, as well as what JDK APIs are usable.
@@ -62,14 +63,6 @@ tasks {
     }
     javadoc {
         options.encoding = Charsets.UTF_8.name() // We want UTF-8 for everything
-    }
-    shadowJar {
-        minimize()
-        relocate("com.github.retrooper.packetevents", "xyz.reknown.fastercrystals.packetevents.api")
-        relocate("io.github.retrooper.packetevents", "xyz.reknown.fastercrystals.packetevents.impl")
-        relocate("dev.jorel.commandapi", "xyz.reknown.fastercrystals.commandapi")
-
-        from("../LICENSE")
     }
 }
 
@@ -82,5 +75,5 @@ bukkitPluginYaml {
     authors.add("Jyguy")
     apiVersion = "1.20.5"
     foliaSupported = true
-    softDepend.addAll("PlaceholderAPI", "ProtocolLib", "ProtocolSupport", "ViaVersion", "ViaBackwards", "ViaRewind", "Geyser-Spigot")
+    depend.addAll("packetevents", "CommandAPI")
 }

--- a/src/main/java/xyz/reknown/fastercrystals/FasterCrystals.java
+++ b/src/main/java/xyz/reknown/fastercrystals/FasterCrystals.java
@@ -18,9 +18,6 @@
 package xyz.reknown.fastercrystals;
 
 import com.github.retrooper.packetevents.PacketEvents;
-import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIBukkitConfig;
-import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder;
 import io.github.retrooper.packetevents.util.folia.FoliaScheduler;
 import lombok.Getter;
 import org.bukkit.Bukkit;
@@ -52,25 +49,12 @@ public class FasterCrystals extends JavaPlugin {
     private static final Set<Material> AIR_TYPES = Set.of(Material.AIR, Material.CAVE_AIR, Material.VOID_AIR);
 
     @Override
-    public void onLoad() {
-        PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
-        PacketEvents.getAPI().getSettings()
-                .checkForUpdates(false)
-                .reEncodeByDefault(false);
-        PacketEvents.getAPI().load();
-
-        CommandAPI.onLoad(new CommandAPIBukkitConfig(this)
-                .missingExecutorImplementationMessage("Only players can run this command."));
-    }
-
-    @Override
     public void onEnable() {
         saveDefaultConfig();
 
         this.crystalIds = FoliaScheduler.isFolia() ? new ConcurrentHashMap<>() : new HashMap<>();
         this.users = new Users();
 
-        CommandAPI.onEnable();
         new FastercrystalsCommand().register();
 
         getServer().getPluginManager().registerEvents(new EntityRemoveFromWorldListener(), this);
@@ -82,7 +66,6 @@ public class FasterCrystals extends JavaPlugin {
         PacketEvents.getAPI().getEventManager().registerListener(new AnimationListener());
         PacketEvents.getAPI().getEventManager().registerListener(new InteractEntityListener());
         PacketEvents.getAPI().getEventManager().registerListener(new LastPacketListener());
-        PacketEvents.getAPI().init();
 
         // Register PlaceholderAPI expansions
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
@@ -91,12 +74,6 @@ public class FasterCrystals extends JavaPlugin {
 
         int pluginId = 22397;
         new Metrics(this, pluginId);
-    }
-
-    @Override
-    public void onDisable() {
-        PacketEvents.getAPI().terminate();
-        CommandAPI.onDisable();
     }
 
     public void spawnCrystal(Location loc, Player player, ItemStack item) {


### PR DESCRIPTION
Closes #39, closes #43.

If more than one plugin is using PacketEvents, it becomes inefficient due to two (or more) instances of it running at the same time.

CommandAPI has its own configuration that should be modifiable by the user without having to forward the configuration through FasterCrystals.

This change is a breaking change since users must now have the plugin variants of [PacketEvents](https://github.com/retrooper/packetevents/tags) and [CommandAPI](https://github.com/CommandAPI/CommandAPI/releases) installed in their plugins folder.

This change also allows supporting new Minecraft releases without releasing a new FasterCrystals version (unless there are significant changes). The process of updating to the latest release for server owners will involve updating PacketEvents and CommandAPI instead, while checking if FasterCrystals is marked as supporting the respective version on Modrinth/Hangar.