### PR TITLE
Add check for cancelled packet

### DIFF
--- a/src/main/java/xyz/reknown/fastercrystals/listeners/packet/AnimationListener.java
+++ b/src/main/java/xyz/reknown/fastercrystals/listeners/packet/AnimationListener.java
@@ -44,12 +44,12 @@ public class AnimationListener extends SimplePacketListenerAbstract {
     public void onPacketPlayReceive(@NonNull PacketPlayReceiveEvent event) {
         if (!FasterCrystalsAPI.isAvailable()) return;
         if (event.getPacketType() != PacketType.Play.Client.ANIMATION) return;
+        if (event.isCancelled()) return;
 
         FasterCrystals plugin = FasterCrystalsAPI.getInstance().getPlugin();
         Player player = event.getPlayer();
 
         User user = plugin.getUsers().get(player);
-        if (event.isCancelled()) return;
         if (player.getGameMode() == GameMode.SPECTATOR) return;
         if (isAttackDamageReduced(player)) return; // ignore reduced hits, tool hits are slow anyway
         if (user == null || !user.isFasterCrystals()) return;

--- a/src/main/java/xyz/reknown/fastercrystals/listeners/packet/AnimationListener.java
+++ b/src/main/java/xyz/reknown/fastercrystals/listeners/packet/AnimationListener.java
@@ -49,6 +49,7 @@ public class AnimationListener extends SimplePacketListenerAbstract {
         Player player = event.getPlayer();
 
         User user = plugin.getUsers().get(player);
+        if (event.isCancelled()) return;
         if (player.getGameMode() == GameMode.SPECTATOR) return;
         if (isAttackDamageReduced(player)) return; // ignore reduced hits, tool hits are slow anyway
         if (user == null || !user.isFasterCrystals()) return;


### PR DESCRIPTION
There is currently no way to prevent FasterCrystals from attacking a crystal when making a player swing their arm, other than manually cancelling the entity damage event itself. This change allows other plugins to more easily and reliably cancel the attack.