### PR TITLE
Fix tab completion filtering, PAPI version sync, and missing license …

### DIFF
--- a/src/main/java/xyz/reknown/fastercrystals/commands/FastercrystalsCommand.java
+++ b/src/main/java/xyz/reknown/fastercrystals/commands/FastercrystalsCommand.java
@@ -103,6 +103,9 @@ public class FastercrystalsCommand implements CommandExecutor, TabCompleter {
 
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        return List.of("reload", "on", "off");
+        if (args.length != 1) return List.of();
+        return List.of("reload", "on", "off").stream()
+                .filter(s -> s.startsWith(args[0].toLowerCase()))
+                .toList();
     }
 }

--- a/src/main/java/xyz/reknown/fastercrystals/papi/FasterCrystalsExpansion.java
+++ b/src/main/java/xyz/reknown/fastercrystals/papi/FasterCrystalsExpansion.java
@@ -44,7 +44,7 @@ public class FasterCrystalsExpansion extends PlaceholderExpansion {
 
     @Override
     public @NotNull String getVersion() {
-        return "1.0.0";
+        return plugin.getDescription().getVersion();
     }
 
     @Override

--- a/src/main/java/xyz/reknown/fastercrystals/repository/CrystalRepository.java
+++ b/src/main/java/xyz/reknown/fastercrystals/repository/CrystalRepository.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023-2025 Jyguy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 package xyz.reknown.fastercrystals.repository;
 
 import org.bukkit.World;


### PR DESCRIPTION
tab completion was returning all options no matter what was typed, 
fixed that so it actually filters properly and returns nothing 
when there's already more than 1 arg.

also noticed FasterCrystalsExpansion had the version hardcoded 
as "1.0.0" instead of reading it from the plugin, and 
CrystalRepository was missing the license header that every 
other file has.