### PR TITLE
Fix for the issue #72

### DIFF
--- a/src/main/java/xyz/reknown/fastercrystals/listener/packet/LastPacketListener.java
+++ b/src/main/java/xyz/reknown/fastercrystals/listener/packet/LastPacketListener.java
@@ -48,6 +48,7 @@ public class LastPacketListener extends SimplePacketListenerAbstract {
         if (!FasterCrystalsAPI.isAvailable()) return;
 
         Player player = event.getPlayer();
+        if (player == null) return;
         CUser cUser = userRepository.get(player);
         if (cUser == null) return;
 


### PR DESCRIPTION
Closes [#72](https://github.com/mcpvp-club/FasterCrystals/issues/72) - `event.getPlayer()` can return `null` before the login/play transition completes, added a null check to bail out early
