### PR TITLE
fix: add missing player null checks in packet listeners

### DIFF
--- a/src/main/java/xyz/reknown/fastercrystals/listener/packet/AnimationListener.java
+++ b/src/main/java/xyz/reknown/fastercrystals/listener/packet/AnimationListener.java
@@ -67,6 +67,7 @@ public class AnimationListener extends SimplePacketListenerAbstract {
         if (event.isCancelled()) return;
 
         final Player player = event.getPlayer();
+        if (player == null) return;
         final CUser cUser = plugin.getUserRepository().get(player);
 
         if (player.getGameMode() == GameMode.SPECTATOR) return;

--- a/src/main/java/xyz/reknown/fastercrystals/listener/packet/InteractEntityListener.java
+++ b/src/main/java/xyz/reknown/fastercrystals/listener/packet/InteractEntityListener.java
@@ -66,6 +66,7 @@ public class InteractEntityListener extends SimplePacketListenerAbstract {
         if (packet.getAction() != WrapperPlayClientInteractEntity.InteractAction.INTERACT_AT) return;
 
         Player player = event.getPlayer();
+        if (player == null) return;
         if (player.getGameMode() == GameMode.SPECTATOR) return;
 
         CUser cUser = userRepository.get(player);


### PR DESCRIPTION
`ProtocolPacketEvent#getPlayer()` is annotated `@UnknownNullability` in packetevents and can return null, e.g. for packets processed before the Bukkit player is attached to the channel. `LastPacketListener` already guards against this, but `AnimationListener` and `InteractEntityListener` call `getGameMode()` / `getUniqueId()` on the player directly, which throws an NPE in the same edge case. This PR adds the same null check to both listeners for consistency.